### PR TITLE
Add FIRE S3 config bits to the Codon config, removed defaults from the env.yml

### DIFF
--- a/conf/codon_slurm.config
+++ b/conf/codon_slurm.config
@@ -23,3 +23,15 @@ workDir = "/hps/nobackup/rdf/metagenomics/service-team/nextflow-workdir/amplicon
 // https://www.nextflow.io/docs/latest/config.html#miscellaneous
 // On a successful completion of a run all files in work directory are automatically deleted.
 cleanup = true
+
+/********************************************/
+/**       EMBL-EBI Fire S3 settings       **/
+/********************************************/
+aws {
+    client {
+        anonymous = true
+        endpoint = 'https://hl.fire.sdo.ebi.ac.uk'
+        s3PathStyleAccess = true
+        signerOverride = "S3SignerType"
+    }
+}

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -4,6 +4,5 @@ name: "mgnify-pipelines-toolkit"
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - "bioconda::mgnify-pipelines-toolkit=0.1.2"


### PR DESCRIPTION
This setting allow us to use FIRE to pull files from ENA ( this only works on EBI network ).

Example samplesheet:
```csv
sample,fastq_1,fastq_2,single_end
ERS2539749,s3://era-public/fastq/ERR263/005/ERR2639105/ERR2639105_1.fastq.gz,s3://era-public/fastq/ERR263/005/ERR2639105/ERR2639105_2.fastq.gz,false
```
FTP urls can be transformed into S3/Fire ones easily, just replace the FTP prefix and add s3://era-public (era-public is the name of the bucket in s3 lingo). 

ATM this mechanism only works for public data.

Example, FTP url `ftp.sra.ebi.ac.uk/vol1/fastq/ERR263/005/ERR2639105/ERR2639105_1.fastq.gz` -> s3 `s3://era-public/fastq/ERR263/005/ERR2639105/ERR2639105_1.fastq.gz`