### PR TITLE
Allow primer validation failure to clobber outputs

### DIFF
--- a/modules/local/primer_validation_classify_var_regions/main.nf
+++ b/modules/local/primer_validation_classify_var_regions/main.nf
@@ -28,8 +28,8 @@ process PRIMER_VALIDATION_CLASSIFY_VAR_REGIONS {
     then
         echo "Primer validation didn't pass. Outputting empty file."
         rm ${meta.id}_primer_validation.tsv ${meta.id}_primers.fasta
-        echo -n > ${meta.id}_primer_validation.tsv
-        echo -n > ${meta.id}_primers.fasta
+        echo -n >| ${meta.id}_primer_validation.tsv
+        echo -n >| ${meta.id}_primers.fasta
     fi
 
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
Nextflow includes `set -C` in shell scripts, which prevents clobbering of existing files. If primer validation fails, this means the pipeline crashes because it tries to overwrite existing files with blank. This PR uses `>|` operator to explicitly allow clobbering in this case.