### PR TITLE
Fixing primer splitting bug

### DIFF
--- a/modules/local/split_primers_by_strand.nf
+++ b/modules/local/split_primers_by_strand.nf
@@ -18,17 +18,17 @@ process SPLIT_PRIMERS_BY_STRAND {
     """
     if [[ -s ${concat_primers} ]]; then
 
-        fwd_flag="\$(grep -A 1 '^>.*F' ${concat_primers} | grep -v -- '^--\$' || true)"
-        rev_flag="\$(grep -A 1 '^>.*R' ${concat_primers} | grep -v -- '^--\$' || true)"
+        fwd_flag="\$(grep -A 1 '^>.*F\$' ${concat_primers} | grep -v -- '^--\$' || true)"
+        rev_flag="\$(grep -A 1 '^>.*R\$' ${concat_primers} | grep -v -- '^--\$' || true)"
 
         if [[ ! -z \$fwd_flag ]]; then
-            grep -A 1 '^>.*F' ${concat_primers} | grep -v -- '^--\$' > ./fwd_primer.fasta
+            grep -A 1 '^>.*F\$' ${concat_primers} | grep -v -- '^--\$' > ./fwd_primer.fasta
         else
             touch ./fwd_primer.fasta
         fi
 
         if [[ ! -z \$rev_flag ]]; then
-            grep -A 1 '^>.*R' ${concat_primers} | grep -v -- '^--\$' > ./rev_primer.fasta
+            grep -A 1 '^>.*R\$' ${concat_primers} | grep -v -- '^--\$' > ./rev_primer.fasta
         else
             touch ./rev_primer.fasta
         fi


### PR DESCRIPTION
I had a bug in envIdent where F and R primers were being outputted into fwd_primer.fasta and rev_primer.fasta. The grep in this module is a little too greedy and anything with an F or R anywhere in its name is matching, eg. >BF1R2|BF1|F ends up in both. Anchoring to the end with $ fixes this. 