### PR TITLE
Add tax_ranks to MapSeq DB config to allow different custom DB names

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The structure is as follows:
     - `run_asv`: true/false for whether this database is used to run ASV analysis
     - `label`: label to be used for naming OTU analysis outputs
     - `asv_label`: label to be used for naming ASV analysis outputs (Required only if `run_asv = true`)
+    - `tax_ranks`: taxonomy rank mode to use for ASV MAPseq output (`DADA2-SILVA` or `DADA2-PR2`; required only if `run_asv = true`)
 
 Examples can be found in `conf/test_dbs.config`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MGnify amplicon analysis pipeline
 
-This repository contains the 1111 [MGnify](https://www.ebi.ac.uk/metagenomics) amplicon analysis pipeline. It is, first and foremost, a refactor of the existing [v5.0 amplicon analysis pipeline](https://github.com/EBI-Metagenomics/pipeline-v5), replacing CWL with [Nextflow](https://www.nextflow.io/) as its workflow management system. This pipeline re-implements all [existing closed-reference v5.0 features](https://docs.mgnify.org/src/docs/analysis.html#amplicon-analysis-pipeline), and makes multiple significant changes and additions.
+This repository contains the v6.1 [MGnify](https://www.ebi.ac.uk/metagenomics) amplicon analysis pipeline. It is, first and foremost, a refactor of the existing [v5.0 amplicon analysis pipeline](https://github.com/EBI-Metagenomics/pipeline-v5), replacing CWL with [Nextflow](https://www.nextflow.io/) as its workflow management system. This pipeline re-implements all [existing closed-reference v5.0 features](https://docs.mgnify.org/src/docs/analysis.html#amplicon-analysis-pipeline), and makes multiple significant changes and additions.
 
 ![V6 Schema](assets/v6_amplicon_schema.png)
 

--- a/conf/test_dbs.config
+++ b/conf/test_dbs.config
@@ -16,6 +16,7 @@ params {
             run_otu = true
             run_asv = true
             asv_label = "DADA2-SILVA"
+            tax_ranks = "DADA2-SILVA"
         }
         silva_lsu {
             fasta = "${projectDir}/assets/test-fixtures/test-ref-dbs/SILVA-LSU/SILVA-LSU_small.fasta"
@@ -35,6 +36,7 @@ params {
             run_otu = true
             run_asv = true
             asv_label = "DADA2-PR2"
+            tax_ranks = "DADA2-PR2"
         }
         itsone {
             fasta = "${projectDir}/assets/test-fixtures/test-ref-dbs/ITSone/ITSone_small.fasta"
@@ -64,4 +66,3 @@ params {
     std_primer_library = ""
 
 }
-

--- a/conf/test_no_otu_dbs.config
+++ b/conf/test_no_otu_dbs.config
@@ -15,6 +15,7 @@ params {
             run_otu   = false
             run_asv   = true
             asv_label = "DADA2-SILVA"
+            tax_ranks = "DADA2-SILVA"
         }
         silva_lsu {
             fasta     = "${projectDir}/assets/test-fixtures/test-ref-dbs/SILVA-LSU/SILVA-LSU_small.fasta"
@@ -34,6 +35,7 @@ params {
             run_otu   = false
             run_asv   = true
             asv_label = "DADA2-PR2"
+            tax_ranks = "DADA2-PR2"
         }
         itsone {
             fasta     = "${projectDir}/assets/test-fixtures/test-ref-dbs/ITSone/ITSone_small.fasta"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,7 +107,7 @@ Some pipeline behavior is controlled through configuration rather than the comma
 - `params.mapseq_databases`
   - Database definitions used for taxonomy assignment.
   - Each entry should define `fasta`, `tax`, `otu`, `mscluster`, `run_otu`, `run_asv`, and `label`.
-  - If `run_asv` is `true`, the entry also needs `asv_label`.
+  - If `run_asv` is `true`, the entry also needs `asv_label` for output naming and `tax_ranks` for ASV taxonomy table formatting. `tax_ranks` must be `DADA2-SILVA` or `DADA2-PR2`.
 - `params.rrnas_rfam_covariance_model`
   - Path to the Rfam covariance model directory used for rRNA detection.
 - `params.rrnas_rfam_claninfo`

--- a/modules/local/mapseq2asvtable/main.nf
+++ b/modules/local/mapseq2asvtable/main.nf
@@ -7,7 +7,7 @@ process MAPSEQ2ASVTABLE {
         "biocontainers/mgnify-pipelines-toolkit:${params.mpt_version}" }"
 
     input:
-    tuple val(meta), path(mapseq_out), val(db_label)
+    tuple val(meta), path(mapseq_out), val(tax_ranks)
 
     output:
     tuple val(meta), path("*.tsv"), emit: asvtaxtable
@@ -15,7 +15,7 @@ process MAPSEQ2ASVTABLE {
 
     script:
     """
-    mapseq_to_asv_table -i $mapseq_out -l $db_label -s ${meta.id}
+    mapseq_to_asv_table -i $mapseq_out -l $tax_ranks -s ${meta.id}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/mapseq2asvtable/tests/main.nf.test
+++ b/modules/local/mapseq2asvtable/tests/main.nf.test
@@ -1,0 +1,35 @@
+nextflow_process {
+
+    name "Test Process MAPSEQ2ASVTABLE"
+    script "../main.nf"
+    process "MAPSEQ2ASVTABLE"
+    tag "modules"
+    tag "mapseq2asvtable"
+
+    test("mapseq2asvtable uses tax_ranks independently of asv_label") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', asv_label:'DADA2-CUSTOM' ],
+                    file('${projectDir}/modules/ebi-metagenomics/mapseq2biom/tests/test.mseq', checkIfExists: true),
+                    "DADA2-PR2"
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.asvtaxtable.get(0).get(0).asv_label == "DADA2-CUSTOM" },
+                { assert path(process.out.asvtaxtable.get(0).get(1)).getFileName().toString() == "test_DADA2-PR2_asv_taxa.tsv" },
+                { assert path(process.out.asvtaxtable.get(0).get(1)).text.contains("Domain") },
+                { assert path(process.out.asvtaxtable.get(0).get(1)).text.contains("Supergroup") }
+            )
+        }
+
+    }
+
+}

--- a/subworkflows/local/mapseq_asv_krona_swf.nf
+++ b/subworkflows/local/mapseq_asv_krona_swf.nf
@@ -29,7 +29,7 @@ workflow MAPSEQ_ASV_KRONA {
             .map{ meta, maps, asv_seqs, _filt_reads -> [meta, [maps, asv_seqs]] }
             .combine(dbs_in)
             .map { asv_meta, asv_files, db_meta, db_files ->
-                def meta = asv_meta + ['db_id': db_meta.id, 'asv_label': db_meta.asv_label]
+                def meta = asv_meta + ['db_id': db_meta.id, 'asv_label': db_meta.asv_label, 'tax_ranks': db_meta.tax_ranks]
                 def (fasta, tax, _otu, mscluster, _label) = db_files
                 def (_maps, asv_seqs) = asv_files
                 return [meta.subMap('id', 'single_end', 'var_region', 'var_regions_size'), [meta, asv_seqs, fasta, tax, mscluster, meta.asv_label]]
@@ -55,7 +55,7 @@ workflow MAPSEQ_ASV_KRONA {
         ch_versions = ch_versions.mix(MAPSEQ.out.versions.first())
 
         mapseq2asvtable_in = MAPSEQ.out.mseq
-            .map { meta, mapseq_out -> [meta, mapseq_out, meta.asv_label] }
+            .map { meta, mapseq_out -> [meta, mapseq_out, meta.tax_ranks] }
         MAPSEQ2ASVTABLE(mapseq2asvtable_in)
         ch_versions = ch_versions.mix(MAPSEQ2ASVTABLE.out.versions.first())
 

--- a/workflows/pipeline.nf
+++ b/workflows/pipeline.nf
@@ -72,7 +72,18 @@ workflow AMPLICON_PIPELINE {
         )
         .filter { it -> it }
         .map { meta, fields -> 
-            def asv_label = fields.run_asv ? ['asv_label': fields.asv_label] : []
+            if (fields.run_asv) {
+                if (!fields.containsKey('asv_label')) {
+                    throw new IllegalArgumentException("ASV database '${meta.id}' has run_asv=true but no asv_label")
+                }
+                if (!fields.containsKey('tax_ranks')) {
+                    throw new IllegalArgumentException("ASV database '${meta.id}' has run_asv=true but no tax_ranks")
+                }
+                if (!(fields.tax_ranks in ['DADA2-SILVA', 'DADA2-PR2'])) {
+                    throw new IllegalArgumentException("ASV database '${meta.id}' has unsupported tax_ranks '${fields.tax_ranks}'. Expected DADA2-SILVA or DADA2-PR2")
+                }
+            }
+            def asv_meta = fields.run_asv ? ['asv_label': fields.asv_label, 'tax_ranks': fields.tax_ranks] : []
             def extra_meta = [
                 'db_label': fields.label,
                 'run_asv': fields.run_asv,
@@ -80,7 +91,7 @@ workflow AMPLICON_PIPELINE {
             ]
 
             [
-                meta + extra_meta + asv_label, 
+                meta + extra_meta + asv_meta, 
                 tuple(
                     file(fields.fasta), 
                     file(fields.tax), 


### PR DESCRIPTION
Needed a different variable for taxonomic rank type (for mapseq2asvtable) separate from the mapseq database name (for the naming of the outputs). So now we have `tax_ranks` and `asv_label`. In current production system`tax_ranks == asv_label`, but with custom databases they may be different e.g. if there are multiple MapSeq DBs all using the SILVA taxonomic ranks.

Added module tests to mapseq2asvtable and added some validation of mapseq config when the config section is parsed at the start of the main pipeline.